### PR TITLE
validate folds in CVScorer

### DIFF
--- a/hessband/cv.py
+++ b/hessband/cv.py
@@ -30,6 +30,10 @@ class CVScorer:
     def __init__(self, X, y, folds=5, kernel='gaussian'):
         self.X = np.asarray(X).ravel()
         self.y = np.asarray(y).ravel()
+        if not (2 <= folds <= len(self.X)):
+            raise ValueError(
+                f"`folds` must be between 2 and {len(self.X)}, got {folds}"
+            )
         self.kf = KFold(n_splits=folds, shuffle=True, random_state=0)
         self.kernel = kernel
         self.evals = 0

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+from hessband.cv import CVScorer
+
+
+def dummy_predict(Xtr, ytr, Xte, h, kernel):
+    """Simple predictor that returns mean of training targets."""
+    return np.mean(ytr) * np.ones_like(Xte)
+
+
+@pytest.mark.parametrize("folds", [2, 10])
+def test_cvscorer_valid_folds(folds):
+    X = np.arange(10)
+    y = np.arange(10)
+    scorer = CVScorer(X, y, folds=folds)
+    mse = scorer.score(dummy_predict, h=0.1)
+    assert np.isfinite(mse)
+
+
+def test_cvscorer_invalid_folds():
+    X = np.arange(5)
+    y = np.arange(5)
+    for bad_folds in [0, 1, 6]:
+        with pytest.raises(ValueError):
+            CVScorer(X, y, folds=bad_folds)


### PR DESCRIPTION
## Summary
- ensure `CVScorer` validates fold count against sample size and raises a helpful error
- add unit tests for valid and invalid `folds` values

## Testing
- `pytest tests/test_cv.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a2371e6dc4832fa2f39f8a24251129